### PR TITLE
install packages fix + no selinux package on Debian + lint fixes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,43 @@
+---
+# Based on ansible-lint config
+extends: default
+ignore: |
+  templates/
+  README.md
+  LICENSE
+  .yamllint
+  .travis.yml
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 2
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length:
+    max: 120
+    level: error
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: true

--- a/tasks/Debian_initial.yml
+++ b/tasks/Debian_initial.yml
@@ -1,14 +1,14 @@
 ---
 - name: Install the required packages in Debian derivatives
-  apt:
+  ansible.builtin.apt:
     name: "{{ item }}"
     state: present
-  loop: "{{ network_pkgs }}"
+  loop: "{{ _network_pkgs }}"
   environment: "{{ env }}"
   when: network_check_packages
 
 - name: Make sure the include line is the only line in interfaces file
-  copy:
+  ansible.builtin.copy:
     content: |
       #
       # Managed by ansible
@@ -16,11 +16,12 @@
 
       source {{ net_path }}/*
     dest: /etc/network/interfaces
+    mode: 0644
   when: network_configured_interfaces_only
   notify: restart networking
 
 - name: Make sure the source include line is there in interfaces file
-  lineinfile:
+  ansible.builtin.lineinfile:
     regexp: '^source\s{{ net_path | regex_escape() }}/\*'
     line: "source {{ net_path }}/*"
     dest: /etc/network/interfaces
@@ -29,13 +30,14 @@
   when: not network_configured_interfaces_only | bool
 
 - name: Make sure the source-directory include line is not there in interfaces file
-  lineinfile:
+  ansible.builtin.lineinfile:
     regexp: '^source-directory\s{{ net_path | regex_escape() }}/?'
     dest: /etc/network/interfaces
     state: absent
   when: not network_configured_interfaces_only | bool
 
 - name: Create the directory for interface cfg files
-  file:
+  ansible.builtin.file:
     path: "{{ net_path }}"
     state: directory
+    mode: 0755

--- a/tasks/Debian_restart.yml
+++ b/tasks/Debian_restart.yml
@@ -6,21 +6,20 @@
 # Tested on Debian Jessie / Ubuntu 14.04 LTS and with Ethernet, Bonding Interfaces
 
 - name: Create a restart script
-  template:
+  ansible.builtin.template:
     src: restartscript.j2
     dest: /etc/network/restart.sh
     mode: 0755
 
 # Execute configuration change
 - name: Execute Network Restart
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     bash /etc/network/restart.sh
-  args:
-    executable: /bin/bash
+  changed_when: false
   failed_when: false
 
 - name: Cleanup Network Restart script
-  file:
+  ansible.builtin.file:
     path: /etc/network/restart.sh
     state: absent

--- a/tasks/RedHat_initial.yml
+++ b/tasks/RedHat_initial.yml
@@ -1,48 +1,52 @@
 ---
-- name: Install the required  packages in Redhat derivatives
-  yum:
+- name: Install the required packages in Redhat derivatives
+  ansible.builtin.yum:
     name: "{{ item }}"
     state: installed
-  loop: "{{ network_pkgs }}"
+  loop: "{{ _network_pkgs }}"
   when: network_check_packages
 
 - name: Write configuration files for rhel route configuration with vlan
-  template:
+  ansible.builtin.template:
     src: "route_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/route-{{ item.device }}"
+    mode: 0644
   loop: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces != [] and item.route is defined
 
 - name: Write configuration files for rhel route configuration
-  template:
+  ansible.builtin.template:
     src: "route_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/route-{{ item.device }}"
+    mode: 0644
   loop: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces != [] and item.route is defined
 
 - name: Write configuration files for route configuration
-  template:
+  ansible.builtin.template:
     src: "route_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/route-{{ item.device }}"
+    mode: 0644
   loop: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces != [] and item.route is defined
 
 - name: Write configuration files for rhel route configuration
-  template:
+  ansible.builtin.template:
     src: "route_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/route-{{ item.device }}"
+    mode: 0644
   loop: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces != [] and item.route is defined
 
 - name: Cleanup gateway dev that does not set to the one we want
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/sysconfig/network
     regexp: "^GATEWAYDEV=(?!{{ gateway_dev }})"
     state: absent
   when: gateway_dev is defined
 
 - name: Explicitly set the gateway device
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/sysconfig/network
     line: "GATEWAYDEV={{ gateway_dev }}"
   when: gateway_dev is defined

--- a/tasks/RedHat_restart.yml
+++ b/tasks/RedHat_restart.yml
@@ -1,36 +1,36 @@
 ---
 - name: Enable the "network" service
-  service:
+  ansible.builtin.service:
     name: network
     enabled: true
-  check_mode: yes
+  check_mode: true
   register: network_service
   ignore_errors: true
   when: network_allow_service_restart
 
 - name: Verify if the "network" service is enabled
-  set_fact:
+  ansible.builtin.set_fact:
     network_service_enabled: "{{ not network_service.failed
         and not network_service.changed }}"
   when: network_allow_service_restart
 
-- name: Enable the "NetworkManager" service
-  service:
-    name: NetworkManager
+- name: Enable the NetworkManager service
+  ansible.builtin.service:
+    name: "NetworkManager"
     enabled: true
-  check_mode: yes
-  register: NetworkManager_service
+  check_mode: true
+  register: network_manager_service
   ignore_errors: true
   when: network_allow_service_restart
 
 - name: Verify if the "NetworkManager" service is enabled
-  set_fact:
-    NetworkManager_service_enabled: "{{ not NetworkManager_service.failed
-        and not NetworkManager_service.changed }}"
+  ansible.builtin.set_fact:
+    network_manager_service_enabled: "{{ not network_manager_service.failed
+        and not network_manager_service.changed }}"
   when: network_allow_service_restart
 
 - name: Restart the "network" service on Red Hat systems
-  service:
+  ansible.builtin.service:
     name: network
     state: restarted
   when: >
@@ -44,12 +44,12 @@
           or bridge_port_result is changed)
 
 - name: Restart the "NetworkManager" service on Red Hat systems
-  service:
+  ansible.builtin.service:
     name: network
     state: restarted
   when: >
     (network_allow_service_restart
-    and NetworkManager_service_enabled) and
+    and network_manager_service_enabled) and
     (ether_result is changed or
      bond_port_result is changed or
      bond_result is changed or

--- a/tasks/bond_interfaces.yml
+++ b/tasks/bond_interfaces.yml
@@ -1,8 +1,9 @@
 ---
 - name: Create the network configuration file for slave in the bond devices
-  template:
+  ansible.builtin.template:
     src: "bond_slave_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.1 }}{{ network_interface_file_postfix }}"
+    mode: 0644
   with_subelements:
     - "{{ network_bond_interfaces }}"
     - bond_slaves
@@ -10,15 +11,16 @@
   notify: restart networking
 
 - name: Create the network configuration file for bond devices
-  template:
+  ansible.builtin.template:
     src: "bond_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.device }}{{ network_interface_file_postfix }}"
+    mode: 0644
   loop: "{{ network_bond_interfaces }}"
   register: bond_result
   notify: restart networking
 
-- name: Make sure the bonding module is loaded
-  modprobe:
+- name: Make sure the bonding module is loaded   # noqa no-handler
+  ansible.builtin.modprobe:
     name: bonding
     state: present
   when: bond_result is changed
@@ -26,7 +28,7 @@
 
 - name: Make the bonding module persistent
   become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: 'bonding'
     dest: /etc/modules
     insertafter: EOF

--- a/tasks/bridge_interfaces.yml
+++ b/tasks/bridge_interfaces.yml
@@ -1,16 +1,18 @@
 ---
 - name: Create the network configuration file for bridge devices
-  template:
+  ansible.builtin.template:
     src: "bridge_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.device }}{{ network_interface_file_postfix }}"
+    mode: 0644
   loop: "{{ network_bridge_interfaces }}"
   register: bridge_result
   notify: restart networking
 
 - name: Create the network configuration file for port on the bridge devices
-  template:
+  ansible.builtin.template:
     src: "bridge_port_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.1 }}{{ network_interface_file_postfix }}"
+    mode: 0644
   with_subelements:
     - '{{ network_bridge_interfaces }}'
     - bridge_ports

--- a/tasks/clean_interfaces.yml
+++ b/tasks/clean_interfaces.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get config files list
-  set_fact:
+  ansible.builtin.set_fact:
     _config_files: "{{ [ _config_files, item ] | flatten | unique }}"
   loop:
     - "{{ network_ether_interfaces | json_query('[*].device') }}"
@@ -9,13 +9,14 @@
     - "{{ network_bridge_interfaces | json_query('[*].device') }}"
 
 - name: Find interface config files to delete
-  find:
+  ansible.builtin.find:
     paths: "{{ net_path }}"
-    excludes: "{{ [ network_interface_file_prefix ] | product(_config_files) | map('join', '') | list | product([ network_interface_file_postfix ]) | map('join', '') | list }}"
+    excludes: "{{ [ network_interface_file_prefix ] | product(_config_files) | map('join', '') | list |
+      product([ network_interface_file_postfix ]) | map('join', '') | list }}"
   register: config_files_to_delete
 
 - name: Remove all interfaces config files not matching the pattern
-  file:
+  ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
   with_items: "{{ config_files_to_delete.files }}"

--- a/tasks/ether_interfaces.yml
+++ b/tasks/ether_interfaces.yml
@@ -1,8 +1,9 @@
 ---
 - name: Create the network configuration file for ethernet interfaces
-  template:
+  ansible.builtin.template:
     src: "ethernet_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.device }}{{ network_interface_file_postfix }}"
+    mode: 0644
   loop: "{{ network_ether_interfaces }}"
   register: ether_result
   notify: restart networking

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Add the OS specific varibles
-  include_vars: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Define network_pkgs.
-  set_fact:
+  ansible.builtin.set_fact:
     network_pkgs: "{{ _network_pkgs }}"
   when: network_pkgs is not defined
 

--- a/tasks/vlan_interfaces.yml
+++ b/tasks/vlan_interfaces.yml
@@ -1,25 +1,26 @@
 ---
 - name: Create the network configuration file for vlan devices
-  template:
+  ansible.builtin.template:
     src: "ethernet_{{ ansible_os_family }}.j2"
     dest: "{{ net_path }}/{{ network_interface_file_prefix }}{{ item.device }}{{ network_interface_file_postfix }}"
+    mode: 0644
   loop: "{{ network_vlan_interfaces }}"
   register: vlan_result
   notify: restart networking
 
-- name: Make sure the 8021q module is loaded
-  modprobe:
+- name: Make sure the 8021q module is loaded   # noqa no-handler
+  ansible.builtin.modprobe:
     name: 8021q
     state: present
   when: vlan_result is changed
   notify: restart networking
 
 - name: Make the 8021q module persistent
-  become: true
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: '8021q'
     dest: /etc/modules
     insertafter: EOF
+  become: true
   when:
     - network_modprobe_persist
   notify: restart networking

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,5 @@
 ---
 _network_pkgs:
-  - python-selinux
   - bridge-utils
   - ifenslave
   - iproute2


### PR DESCRIPTION
1. **Fix:** Not able to restart network beacuse bridge-utils not installed (both RedHat and Debian families). `_network_pkgs` was set in a vars, but both *_initial.yml tasks iterating through the "{{ network_pkgs }}" is not working (tested in Ansible 2.10.7).
2. **Fix:** There is not package `libselinux-python` in Ubuntu16.04. I think it's not required for Debian family at all.
3. **Minor:** Ansible-lint warnings fixes: especially a lot of ansible-builtin and file permissions.
4. **Minor:** File `.ansible-lint` was kept, but it's no needed anymore because of `# noqa <rules_name>` has been added to tasks.
5. **Minor**: `.yamllint` for molecule testing fans has been added :)